### PR TITLE
fix missing `#include <stdlib.h>`

### DIFF
--- a/srcs/test_ft_atoi.c
+++ b/srcs/test_ft_atoi.c
@@ -1,16 +1,17 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   test_ft_aoti.c                                     :+:      :+:    :+:   */
+/*   test_ft_atoi.c                                     :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 11:05:54 by susami            #+#    #+#             */
-/*   Updated: 2022/04/15 16:15:12 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/19 00:02:05 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "libft.h"
 #include "libassert.h"
@@ -56,7 +57,7 @@ int	main(void)
 	/* 35. LONG_MIN + 1 */ ASSERT_EQ_I(atoi("-9223372036854775807"), ft_atoi("-9223372036854775807"));
 	/* 36. ULONG_MAX - 1 */ ASSERT_EQ_I(atoi("18446744073709551614"), ft_atoi("18446744073709551614"));
 	/* 37. SIZE_MAX - 1 */ ASSERT_EQ_I(atoi("18446744073709551614"), ft_atoi("18446744073709551614"));
-	
+
 	/* 38. Many zeros 1*/ ASSERT_EQ_I(atoi("000000000000000000008"), ft_atoi("000000000000000000008"));
 	/* 39. Many zeros 2*/ ASSERT_EQ_I(atoi("-000000000000000000008"), ft_atoi("-000000000000000000008"));
 	/* 40. Many zeros 3*/ ASSERT_EQ_I(atoi("+000000000000000000008"), ft_atoi("+000000000000000000008"));

--- a/srcs/test_ft_bzero.c
+++ b/srcs/test_ft_bzero.c
@@ -3,18 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_bzero.c                                    :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 17:40:45 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 10:22:58 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/19 00:28:43 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "libft.h"
 #include "libassert.h"
-#include <malloc/malloc.h>
 
 void	check_bzero(char *s1, char *s2, size_t size)
 {
@@ -30,7 +30,7 @@ void	check_bzero(char *s1, char *s2, size_t size)
 int	main(void)
 {
 	char	*s1, *s2;
-	
+
 	/* 1 */ s1 = malloc(100); s2 = malloc(100); check_bzero(s1, s2, 0); free(s1); free(s2);
 	/* 2 */ s1 = malloc(100); s2 = malloc(100); check_bzero(s1, s2, 1); free(s1); free(s2);
 	/* 3 */ s1 = malloc(100); s2 = malloc(100); check_bzero(s1, s2, 42); free(s1); free(s2);

--- a/srcs/test_ft_calloc.c
+++ b/srcs/test_ft_calloc.c
@@ -6,16 +6,16 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 12:10:25 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 22:16:19 by kfujita          ###   ########.fr       */
+/*   Updated: 2022/04/19 00:28:51 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <limits.h>
 #include "libft.h"
 #include "libassert.h"
-#include <malloc/malloc.h>
 
 void	check_calloc(size_t cnt, size_t size)
 {

--- a/srcs/test_ft_calloc.c
+++ b/srcs/test_ft_calloc.c
@@ -1,17 +1,18 @@
 /* ************************************************************************** */
 /*                                                                            */
 /*                                                        :::      ::::::::   */
-/*   test_calloc.c                                      :+:      :+:    :+:   */
+/*   test_ft_calloc.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 12:10:25 by susami            #+#    #+#             */
-/*   Updated: 2022/04/15 19:13:34 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:16:19 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 #include <malloc/malloc.h>

--- a/srcs/test_ft_isalnum.c
+++ b/srcs/test_ft_isalnum.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_isalnum.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 16:53:15 by susami            #+#    #+#             */
-/*   Updated: 2022/04/15 16:54:22 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:16:30 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 

--- a/srcs/test_ft_isalpha.c
+++ b/srcs/test_ft_isalpha.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_isalpha.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 16:35:50 by susami            #+#    #+#             */
-/*   Updated: 2022/04/15 19:41:38 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:14:30 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 

--- a/srcs/test_ft_isascii.c
+++ b/srcs/test_ft_isascii.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_isascii.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 16:54:50 by susami            #+#    #+#             */
-/*   Updated: 2022/04/15 16:55:13 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:14:39 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 

--- a/srcs/test_ft_isdigit.c
+++ b/srcs/test_ft_isdigit.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_isdigit.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 16:51:05 by susami            #+#    #+#             */
-/*   Updated: 2022/04/15 16:52:49 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:14:48 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 

--- a/srcs/test_ft_isprint.c
+++ b/srcs/test_ft_isprint.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_isprint.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 16:56:06 by susami            #+#    #+#             */
-/*   Updated: 2022/04/15 16:56:32 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:14:56 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 

--- a/srcs/test_ft_memchr.c
+++ b/srcs/test_ft_memchr.c
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_memchr.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 08:41:43 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 08:55:58 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 23:50:42 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include "libft.h"

--- a/srcs/test_ft_memcmp.c
+++ b/srcs/test_ft_memcmp.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_memcmp.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 08:56:22 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 09:05:51 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:16:49 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 

--- a/srcs/test_ft_memcmp.c
+++ b/srcs/test_ft_memcmp.c
@@ -6,11 +6,12 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 08:56:22 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 22:16:49 by kfujita          ###   ########.fr       */
+/*   Updated: 2022/04/18 23:48:17 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <limits.h>

--- a/srcs/test_ft_memcpy.c
+++ b/srcs/test_ft_memcpy.c
@@ -3,18 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_memcpy.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 18:04:04 by susami            #+#    #+#             */
-/*   Updated: 2022/04/15 19:09:17 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/19 00:29:03 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "libft.h"
 #include "libassert.h"
-#include <malloc/malloc.h>
 
 void	check_memcpy(void *dst, void *src, size_t size)
 {

--- a/srcs/test_ft_memmove.c
+++ b/srcs/test_ft_memmove.c
@@ -3,18 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_memmove.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 19:09:36 by susami            #+#    #+#             */
-/*   Updated: 2022/04/15 19:10:53 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/19 00:29:07 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "libft.h"
 #include "libassert.h"
-#include <malloc/malloc.h>
 
 void	check_memmove(void *dst, void *src, size_t size)
 {

--- a/srcs/test_ft_memset.c
+++ b/srcs/test_ft_memset.c
@@ -3,15 +3,16 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_memset.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 17:11:14 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 08:09:32 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:17:59 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 #include <malloc/malloc.h>

--- a/srcs/test_ft_memset.c
+++ b/srcs/test_ft_memset.c
@@ -6,16 +6,16 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/15 17:11:14 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 22:17:59 by kfujita          ###   ########.fr       */
+/*   Updated: 2022/04/19 00:29:11 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <limits.h>
 #include "libft.h"
 #include "libassert.h"
-#include <malloc/malloc.h>
 
 void	check_memset(char *s1, char *s2, int val, size_t size)
 {
@@ -27,7 +27,7 @@ void	check_memset(char *s1, char *s2, int val, size_t size)
 int	main(void)
 {
 	char	*s1, *s2;
-	
+
 	/* 1 */ s1 = calloc(100, 100); s2 = calloc(100, 100); check_memset(s1, s2, 0, 0); free(s1); free(s2);
 	/* 2 */ s1 = calloc(100, 100); s2 = calloc(100, 100); check_memset(s1, s2, 1, 0); free(s1); free(s2);
 	/* 3 */ s1 = calloc(100, 100); s2 = calloc(100, 100); check_memset(s1, s2, 0, 1); free(s1); free(s2);

--- a/srcs/test_ft_strdup.c
+++ b/srcs/test_ft_strdup.c
@@ -3,18 +3,18 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_strdup.c                                   :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 10:25:42 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 10:31:36 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/19 00:17:36 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include "libft.h"
 #include "libassert.h"
-#include <malloc/malloc.h>
 
 void	check_strdup(char *str)
 {

--- a/srcs/test_ft_strjoin.c
+++ b/srcs/test_ft_strjoin.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_strjoin.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 16:20:37 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 16:25:34 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/19 00:30:23 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,6 @@
 #include <string.h>
 #include "libft.h"
 #include "libassert.h"
-#include <malloc/malloc.h>
 
 int	main(void)
 {

--- a/srcs/test_ft_strlcat.c
+++ b/srcs/test_ft_strlcat.c
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_strlcat.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/17 21:16:21 by susami            #+#    #+#             */
-/*   Updated: 2022/04/17 21:40:47 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 23:49:57 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include "libft.h"

--- a/srcs/test_ft_strlcpy.c
+++ b/srcs/test_ft_strlcpy.c
@@ -3,14 +3,15 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_strlcpy.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/17 21:57:05 by susami            #+#    #+#             */
-/*   Updated: 2022/04/17 22:19:38 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 23:50:10 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include "libft.h"

--- a/srcs/test_ft_strncmp.c
+++ b/srcs/test_ft_strncmp.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_strncmp.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 08:17:32 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 08:37:03 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:18:38 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 

--- a/srcs/test_ft_strncmp.c
+++ b/srcs/test_ft_strncmp.c
@@ -6,11 +6,12 @@
 /*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 08:17:32 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 22:18:38 by kfujita          ###   ########.fr       */
+/*   Updated: 2022/04/18 23:49:06 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <ctype.h>
 #include <limits.h>

--- a/srcs/test_ft_strtrim.c
+++ b/srcs/test_ft_strtrim.c
@@ -3,10 +3,10 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_strtrim.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/18 16:26:25 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 16:32:14 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/19 00:30:30 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -14,7 +14,6 @@
 #include <string.h>
 #include "libft.h"
 #include "libassert.h"
-#include <malloc/malloc.h>
 
 int	main(void)
 {

--- a/srcs/test_ft_tolower.c
+++ b/srcs/test_ft_tolower.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_tolower.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/17 22:28:39 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 08:14:40 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:19:11 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 

--- a/srcs/test_ft_toupper.c
+++ b/srcs/test_ft_toupper.c
@@ -3,16 +3,17 @@
 /*                                                        :::      ::::::::   */
 /*   test_ft_toupper.c                                  :+:      :+:    :+:   */
 /*                                                    +:+ +:+         +:+     */
-/*   By: susami <susami@student.42tokyo.jp>         +#+  +:+       +#+        */
+/*   By: kfujita <kfujita@student.42tokyo.jp>       +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/17 22:22:06 by susami            #+#    #+#             */
-/*   Updated: 2022/04/18 08:13:53 by susami           ###   ########.fr       */
+/*   Updated: 2022/04/18 22:19:35 by kfujita          ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include <stdio.h>
 #include <string.h>
 #include <ctype.h>
+#include <limits.h>
 #include "libft.h"
 #include "libassert.h"
 


### PR DESCRIPTION
I fixed 2 similar errors with this PR.

---

In Guacamole of 42Tokyo, the header file `malloc/malloc.h` is missing.

So, I replaced to including `stdlib.h` to use `malloc` or removed when it is unused.

![image](https://user-images.githubusercontent.com/31824852/163833886-ddfe9233-fb26-4006-8427-905735c5b18c.png)


---

In some files, `atoi`, `calloc` and `free` were used without including `stdlib.h`.

This causes a compile error (like below).

```:error sample
ft_atoi: srcs/test_ft_atoi.c:20:35: error: implicit declaration of function 'atoi' is invalid in C99 [-Werror,-Wimplicit-function-declaration]
        /* 1 */ ASSERT_EQ_I(ft_atoi(""), atoi(""));
                                         ^
1 error generated.
```
To correct those error, I included stdlib.h in the necessary files.