### PR TITLE
add missing `#include <limits.h>` to tester.h

### DIFF
--- a/includes/tester.h
+++ b/includes/tester.h
@@ -18,6 +18,7 @@
 # include <string.h>
 # include <ctype.h>
 # include <fcntl.h>
+# include <limits.h>
 # include "libft.h"
 # include "libassert.h"
 


### PR DESCRIPTION
In some files, `INT_MAX`, etc. were used but `limits.h` was not included.  This causes a compile error that says missing declaring `INT_MAX`, etc.

To correct this error, I added `#include <limits.h>` into the `tester.h` file.