### PR TITLE
:sparkles: Support Reloaded cursus (Libft-00 ~ Libft-02)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,9 +12,12 @@
 
 LIBFT_DIR		=	../
 LIBFT			=	$(LIBFT_DIR)libft.a
+LIBFT_00		=	$(LIBFT_DIR)libft00.a
+LIBFT_01		=	$(LIBFT_DIR)libft01.a
+LIBFT_02		=	$(LIBFT_DIR)libft02.a
 LIBASSERT_DIR	=	./libs/libassert/
 LIBASSERT		=	$(LIBASSERT_DIR)libassert.a
-LIBS			= 	$(LIBFT) ./libs/*/*.a
+LIBS			= 	./libs/*/*.a
 CC				=	gcc
 CFLAGS			=	-Wall -Wextra -Werror
 INCS			=	./includes\
@@ -23,7 +26,8 @@ INCS			=	./includes\
 SRCS			=	srcs/*.c
 OBJS			=	$(SRCS:%.c=$(OUT_O_DIR)/%.o)
 OBJ_DIR			=	objs
-FUNCS_PART1		=	isalpha\
+
+FUNCS_LIBFT00	=	isalpha\
 					isdigit\
 					isalnum\
 					isascii\
@@ -35,7 +39,8 @@ FUNCS_PART1		=	isalpha\
 					memmove\
 					strlcpy\
 					strlcat\
-					toupper\
+
+FUNCS_LIBFT01	=	toupper\
 					tolower\
 					strchr\
 					strrchr\
@@ -44,14 +49,24 @@ FUNCS_PART1		=	isalpha\
 					memcmp\
 					strnstr\
 					atoi\
-					calloc\
+
+FUNCS_LIBFT02_1	=	calloc\
 					strdup\
 
-FUNCS_PART2		=	substr\
+FUNCS_LIBFT02_2	=	substr\
 					strjoin\
 					strtrim\
 					split\
 					itoa\
+
+FUNCS_LIBFT02	=	$(FUNCS_LIBFT02_1)\
+					$(FUNCS_LIBFT02_2)\
+
+FUNCS_PART1		=	$(FUNCS_LIBFT00)\
+					$(FUNCS_LIBFT01)\
+					$(FUNCS_LIBFT02_1)\
+
+FUNCS_PART2		=	$(FUNCS_LIBFT02_2)\
 					strmapi\
 					striteri\
 					putchar_fd\
@@ -70,7 +85,19 @@ FUNCS_BONUS		=	lstnew\
 					lstmap\
 
 FUNCS_EXTRA		=	strcmp\
-					
+
+RE_LIBFT00_TARG	=	$(addsuffix .re, $(FUNCS_LIBFT00))
+RE_LIBFT01_TARG	=	$(addsuffix .re, $(FUNCS_LIBFT01))
+RE_LIBFT02_TARG	=	$(addsuffix .re, $(FUNCS_LIBFT02))
+
+SRCS_LIBFT00	= $(shell ls $(addprefix $(LIBFT_DIR)ft_, $(addsuffix .c, $(FUNCS_LIBFT00))) 2> /dev/null)
+SRCS_LIBFT01	= $(shell ls $(addprefix $(LIBFT_DIR)ft_, $(addsuffix .c, $(FUNCS_LIBFT01))) 2> /dev/null)
+SRCS_LIBFT02	= $(shell ls $(addprefix $(LIBFT_DIR)ft_, $(addsuffix .c, $(FUNCS_LIBFT02))) 2> /dev/null)
+
+OBJS_LIBFT00	= $(SRCS_LIBFT00:.c=.o)
+OBJS_LIBFT01	= $(SRCS_LIBFT01:.c=.o)
+OBJS_LIBFT02	= $(SRCS_LIBFT02:.c=.o)
+
 FUNCS			= $(FUNCS_PART1) $(FUNCS_PART2)
 ERROR_LOG		=	error.log
 
@@ -97,6 +124,31 @@ extra: start_bonus_tests $(FUNCS_EXTRA)
 		\n[EXTRA] All tests passed successfully! Congratulations :D\n\e[m" ||\
 		printf "\e[31m\n\n------------------------------------------------------------\
 		\nSome tests failed. Please see error.log for more detailed information.\n\e[m"
+
+libft-00: start_reloaded_tests $(RE_LIBFT00_TARG)
+	@find . -name "*.log" -size 0 -exec rm {} \;
+	@[ ! -f $(ERROR_LOG) ] &&\
+		printf "\e[32m\n\n------------------------------------------------------------\
+		\n[Libft-00] All tests passed successfully! Congratulations :D\n\e[m" ||\
+		printf "\e[31m\n\n------------------------------------------------------------\
+		\nSome tests failed. Please see error.log for more detailed information.\n\e[m"
+
+libft-01: start_reloaded_tests $(RE_LIBFT01_TARG)
+	@find . -name "*.log" -size 0 -exec rm {} \;
+	@[ ! -f $(ERROR_LOG) ] &&\
+		printf "\e[32m\n\n------------------------------------------------------------\
+		\n[Libft-01] All tests passed successfully! Congratulations :D\n\e[m" ||\
+		printf "\e[31m\n\n------------------------------------------------------------\
+		\nSome tests failed. Please see error.log for more detailed information.\n\e[m"
+
+libft-02: start_reloaded_tests $(RE_LIBFT02_TARG)
+	@find . -name "*.log" -size 0 -exec rm {} \;
+	@[ ! -f $(ERROR_LOG) ] &&\
+		printf "\e[32m\n\n------------------------------------------------------------\
+		\n[Libft-02] All tests passed successfully! Congratulations :D\n\e[m" ||\
+		printf "\e[31m\n\n------------------------------------------------------------\
+		\nSome tests failed. Please see error.log for more detailed information.\n\e[m"
+
 start_tests:
 	@$(RM) $(ERROR_LOG)
 	make -C $(LIBFT_DIR)
@@ -108,8 +160,21 @@ start_bonus_tests:
 	make -C $(LIBFT_DIR) bonus
 	make -C ./libs/libassert
 
+start_reloaded_tests:
+	@$(RM) $(ERROR_LOG)
+	make -C ./libs/libassert
+
 $(LIBFT):
 	make -C $(LIBFT_DIR)
+
+$(LIBFT_00): $(OBJS_LIBFT00)
+	ar rc $@ $^
+
+$(LIBFT_01): $(OBJS_LIBFT00) $(OBJS_LIBFT01)
+	ar rc $@ $^
+
+$(LIBFT_02): $(OBJS_LIBFT00) $(OBJS_LIBFT01) $(OBJS_LIBFT02)
+	ar rc $@ $^
 
 $(LIBASSERT):
 	make -C ./libs/libassert
@@ -141,7 +206,22 @@ norm:
 
 $(FUNCS) $(FUNCS_BONUS) $(FUNCS_EXTRA): $(LIBFT) $(LIBASSERT)
 	@printf "ft_$@: "
-	@-$(CC) srcs/test_ft_$@.c $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
+	@-$(CC) srcs/test_ft_$@.c $(LIBFT) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
+	@printf "\n"
+
+$(RE_LIBFT00_TARG): $(LIBFT_00) $(LIBASSERT)
+	@printf "ft_$(basename $@): "
+	@-$(CC) srcs/test_ft_$(basename $@).c $(LIBFT_00) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
+	@printf "\n"
+
+$(RE_LIBFT01_TARG): $(LIBFT_01) $(LIBASSERT)
+	@printf "ft_$(basename $@): "
+	@-$(CC) srcs/test_ft_$(basename $@).c $(LIBFT_01) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
+	@printf "\n"
+
+$(RE_LIBFT02_TARG): $(LIBFT_02) $(LIBASSERT)
+	@printf "ft_$(basename $@): "
+	@-$(CC) srcs/test_ft_$(basename $@).c $(LIBFT_02) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
 	@printf "\n"
 
 .PHONY: all clean fclean re bonus norm test clone

--- a/Makefile
+++ b/Makefile
@@ -204,6 +204,13 @@ norm:
 	@echo "------------------------------Checking norminette------------------------------"
 	norminette $(LIBFT_DIR)*.c $(LIBFT_DIR)*.h | grep -v "OK!" || printf "\e[32mnorminette OK :D\n\e[m"
 
+norm00: $(LIBFT_00)
+	make norm LIBFT=$<
+norm01: $(LIBFT_01)
+	make norm LIBFT=$<
+norm02: $(LIBFT_02)
+	make norm LIBFT=$<
+
 $(FUNCS) $(FUNCS_BONUS) $(FUNCS_EXTRA): $(LIBFT) $(LIBASSERT)
 	@printf "ft_$@: "
 	@-$(CC) srcs/test_ft_$@.c $(LIBFT) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ $ make LIBFT_DIR=/path/to/your/libft/dir
 $ make all
 ```
 
+If you want to test Libft-00 ~ Libft-02, please use below.  (Please change part number `00` to same as your project.)
+
+```
+$ make libft-00
+```
+
 <img width="1388" alt="Screen Shot 2022-04-18 at 9 34 55" src="https://user-images.githubusercontent.com/7609060/163738262-2070f78d-83e2-4585-83d4-c65edbcdcddb.png">
 
 ## 3. Test Bonus functions
@@ -34,6 +40,14 @@ $ make bonus
 $ make strlen
 $ make atoi
 $ make strnstr
+```
+
+If you want to test functions when trying to Libft-00 ~ Libft-02, please type with suffix `.re` like below.
+
+```
+$ make strlen.re
+$ make atoi.re
+$ make strnstr.re
 ```
 
 <img width="1386" alt="Screen Shot 2022-04-18 at 9 35 27" src="https://user-images.githubusercontent.com/7609060/163738259-a04237e5-d66d-4694-b323-8739b194fe12.png">

--- a/README.md
+++ b/README.md
@@ -57,6 +57,12 @@ $ make strnstr.re
 $ make norm
 ```
 
+If you want to run norm check for Libft-00 ~ Libft-02, please use below.  (Please change part number `00` to same as your project.)
+
+```
+$ make norm00
+```
+
 <img width="1369" alt="Screen Shot 2022-04-18 at 15 27 40" src="https://user-images.githubusercontent.com/7609060/163765260-3fad885b-e00a-4b3f-9468-cc998ae5cb24.png">
 
 


### PR DESCRIPTION
ご存知の通り、42TokyoにはLibftの分割版課題が用意されています。
分割版課題では、本家のMandatoryをLibft-00 ~ Libft-03のように4分割しており、Makefileでアーカイブファイルを作成する指示はLibft-03に含まれています。

さて、現状このテスターは「LibftプロジェクトでMakefileが作成済みであり、そのMakefileで`libft.a`が作成されていること」を前提に組まれています。
しかし、先述のようにLibft-00 ~ Libft-02ではMakefileもアーカイブファイルも用いないため、そのままではこのテスターを使用できません。
なので、この分割libftへのサポートを追加してみました。

## 変更した実装での注意点など

- 記述量削減のため、関数名の列挙を分割版ベースに変更しています
- Libft-01とLibft-02では以前の課題で作成した関数を使用できるため、「Libftディレクトリにある、使用可能な関数のファイル」のみを列挙してアーカイブするようにしています
- 分割版Libftのアーカイブファイル名が`libft.a`ではないため、テストを実行する関数ごとのターゲット名は、suffixとしてReloadedの`re`を付加したものにしています

## Ready to Review前にやること

- [x] READMEに使い方やスクショを載せる

Makefileの記法に関する指摘や、READMEの書き方についての注意事項等あれば、ご教授いただけると嬉しいです。