### PR TITLE
libft-tester-tokyoを42Tokyo Ubuntu22.04環境に対応させるための修正

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ norm02: $(LIBFT_02)
 
 $(FUNCS) $(FUNCS_BONUS) $(FUNCS_EXTRA): $(LIBFT) $(LIBASSERT)
 	@printf "ft_$@: "
-	@-$(CC) srcs/test_ft_$@.c $(LIBFT) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
+	@-$(CC) srcs/test_ft_$@.c $(LIBFT) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) $(LDFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
 	@printf "\n"
 
 $(RE_LIBFT00_TARG): $(LIBFT_00) $(LIBASSERT)

--- a/Makefile
+++ b/Makefile
@@ -21,10 +21,11 @@ LIBS			= 	./libs/*/*.a
 CC				=	gcc
 CFLAGS			=	-Wall -Wextra -Werror
 LDFLAGS =
-
+PICFLAG =
 UNAME_S := $(shell uname -s)
 ifeq ($(UNAME_S),Linux)
     LDFLAGS += -lbsd
+	PICFLAG += CFLAGS="-Wall -Wextra -Werror -fPIC"
 endif
 
 INCS			=	./includes\
@@ -158,7 +159,7 @@ libft-02: start_reloaded_tests $(RE_LIBFT02_TARG)
 
 start_tests:
 	@$(RM) $(ERROR_LOG)
-	make -C $(LIBFT_DIR) CFLAGS="-Wall -Wextra -Werror -fPIC"
+	make -C $(LIBFT_DIR) $(PICFLAG)
 	make -C ./libs/libassert
 	@#make -C $(LIBFT_DIR) bonus
 

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,13 @@ LIBASSERT		=	$(LIBASSERT_DIR)libassert.a
 LIBS			= 	./libs/*/*.a
 CC				=	gcc
 CFLAGS			=	-Wall -Wextra -Werror
+LDFLAGS =
+
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+    LDFLAGS += -lbsd
+endif
+
 INCS			=	./includes\
 					$(LIBFT_DIR)\
 
@@ -151,7 +158,7 @@ libft-02: start_reloaded_tests $(RE_LIBFT02_TARG)
 
 start_tests:
 	@$(RM) $(ERROR_LOG)
-	make -C $(LIBFT_DIR)
+	make -C $(LIBFT_DIR) CFLAGS="-Wall -Wextra -Werror -fPIC"
 	make -C ./libs/libassert
 	@#make -C $(LIBFT_DIR) bonus
 
@@ -213,7 +220,7 @@ norm02: $(LIBFT_02)
 
 $(FUNCS) $(FUNCS_BONUS) $(FUNCS_EXTRA): $(LIBFT) $(LIBASSERT)
 	@printf "ft_$@: "
-	@-$(CC) srcs/test_ft_$@.c $(LIBFT) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
+	@-$(CC) srcs/test_ft_$@.c $(LIBFT) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) $(LDFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
 	@printf "\n"
 
 $(RE_LIBFT00_TARG): $(LIBFT_00) $(LIBASSERT)

--- a/Makefile
+++ b/Makefile
@@ -221,7 +221,7 @@ norm02: $(LIBFT_02)
 
 $(FUNCS) $(FUNCS_BONUS) $(FUNCS_EXTRA): $(LIBFT) $(LIBASSERT)
 	@printf "ft_$@: "
-	@-$(CC) srcs/test_ft_$@.c $(LIBFT) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) $(LDFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
+	@-$(CC) srcs/test_ft_$@.c $(LIBFT) $(LIBS) $(addprefix -I , $(INCS)) -o a.out $(CFLAGS) 2>>$(ERROR_LOG) && ./a.out 2>>$(ERROR_LOG) && $(RM) a.out || printf "\e[31m[MISSING]\e[m"
 	@printf "\n"
 
 $(RE_LIBFT00_TARG): $(LIBFT_00) $(LIBASSERT)

--- a/README.md
+++ b/README.md
@@ -66,11 +66,11 @@ $ make norm00
 <img width="1369" alt="Screen Shot 2022-04-18 at 15 27 40" src="https://user-images.githubusercontent.com/7609060/163765260-3fad885b-e00a-4b3f-9468-cc998ae5cb24.png">
 
 ## Note for use with Linux (Ubuntu 22.04)
-Only when the test is run, CFLAGS in the Mikefile in libft is temporarily rewritten to the following
+Only when the test is run, `CFLAGS` in the Mikefile in libft is temporarily rewritten to the following
 ```
 CFLAGS　=　-Wall -Wextra -Werror -fPIC
 ```
-If you have written anything other than -Wall -Wextra -Werror in CFLAGS, or -Wall -Wextra -Werror elsewhere, please be careful!
+If you have written anything other than `-Wall -Wextra -Werror` in `CFLAGS`, or `-Wall -Wextra -Werror` elsewhere, please be careful!
 
 # Please add more test cases!
 Thanks for trying it out!

--- a/README.md
+++ b/README.md
@@ -65,6 +65,12 @@ $ make norm00
 
 <img width="1369" alt="Screen Shot 2022-04-18 at 15 27 40" src="https://user-images.githubusercontent.com/7609060/163765260-3fad885b-e00a-4b3f-9468-cc998ae5cb24.png">
 
+## Note for use with Linux (Ubuntu 22.04)
+Only when the test is run, CFLAGS in the Mikefile in libft is temporarily rewritten to the following
+```
+CFLAGS　=　-Wall -Wextra -Werror -fPIC
+```
+If you have written anything other than -Wall -Wextra -Werror in CFLAGS, or -Wall -Wextra -Werror elsewhere, please be careful!
 
 # Please add more test cases!
 Thanks for trying it out!

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+# Libft-tester-tokyo
+This tester was created with the goal of achieving perfect one-to-one behavior with the actual function. Therefore, results may vary depending on the C library environment used.
+
 # How to use
 
 1. Clone this repository to the root directory of your libft repository.
@@ -66,11 +69,12 @@ $ make norm00
 <img width="1369" alt="Screen Shot 2022-04-18 at 15 27 40" src="https://user-images.githubusercontent.com/7609060/163765260-3fad885b-e00a-4b3f-9468-cc998ae5cb24.png">
 
 ## Note for use with Linux (Ubuntu 22.04)
-Only when the test is run, `CFLAGS` in the Mikefile in libft is temporarily rewritten to the following
+Only when the test is run, `CFLAGS` in the Makefile in libft is temporarily rewritten to the following
 ```
 CFLAGS　=　-Wall -Wextra -Werror -fPIC
 ```
 If you have written anything other than `-Wall -Wextra -Werror` in `CFLAGS`, or `-Wall -Wextra -Werror` elsewhere, please be careful!
+This is an option to support the 42Tokyo Ubuntu 22.04 environment. It is not required for other Ubuntu environments.
 
 # Please add more test cases!
 Thanks for trying it out!

--- a/README.md
+++ b/README.md
@@ -68,14 +68,20 @@ $ make norm00
 
 <img width="1369" alt="Screen Shot 2022-04-18 at 15 27 40" src="https://user-images.githubusercontent.com/7609060/163765260-3fad885b-e00a-4b3f-9468-cc998ae5cb24.png">
 
-## Note for use with Linux (Ubuntu 22.04)
+# Note for use with Linux (Ubuntu 22.04)
+## For all Linux (Ubuntu 22.04)
 Only when the test is run, `CFLAGS` in the Makefile in libft is temporarily rewritten to the following
 ```
 CFLAGS　=　-Wall -Wextra -Werror -fPIC
 ```
 If you have written anything other than `-Wall -Wextra -Werror` in `CFLAGS`, or `-Wall -Wextra -Werror` elsewhere, please be careful!
 This is an option to support the 42Tokyo Ubuntu 22.04 environment. It is not required for other Ubuntu environments.
-
+## For Linux environments except 42Tokyo (Ubuntu 22.04)
+Before executing the code, you must install the libbsd package beforehand by running the following
+```
+sudo apt-get update
+sudo apt-get install libbsd-dev
+```
 # Please add more test cases!
 Thanks for trying it out!
 If you notice anything or want to add some test cases, feel free to send issues/PRs!

--- a/includes/tester.h
+++ b/includes/tester.h
@@ -13,10 +13,17 @@
 #ifndef TESTER_H
 # define TESTER_H
 
+#ifdef __linux__
+# include <bsd/string.h>
+# include <stdint.h>
+# include <sys/stat.h>
+#else
+# include <string.h>
+#endif
+
 # include <limits.h>
 # include <stdio.h>
 # include <stdlib.h>
-# include <string.h>
 # include <ctype.h>
 # include <fcntl.h>
 # include "libft.h"

--- a/libs/libassert/Makefile
+++ b/libs/libassert/Makefile
@@ -17,6 +17,11 @@ OBJS	=	$(SRCS:%.c=$(OBJ_DIR)/%.o)
 NAME	=	libassert.a
 RM		=	rm -f
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Linux)
+    CFLAGS +=  -fPIC
+endif
+
 all: $(NAME)
 
 $(NAME): $(OBJS)

--- a/libs/libassert/libassert.c
+++ b/libs/libassert/libassert.c
@@ -10,11 +10,17 @@
 /*                                                                            */
 /* ************************************************************************** */
 
+#ifdef __linux__
+#include <malloc.h>
+#define MALLOC_SIZE(ptr) malloc_usable_size(ptr)
+#else
+#include <malloc/malloc.h>
+#define MALLOC_SIZE(ptr) malloc_size(ptr)
+#endif
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdarg.h>
-#include <malloc/malloc.h>
 #define ANSI_COLOR_RED     "\x1b[1;31m"
 #define ANSI_COLOR_GREEN   "\x1b[1;32m"
 #define ANSI_COLOR_YELLOW  "\x1b[1;33m"
@@ -250,10 +256,10 @@ void	ASSERT_EQ_MALLOC_SIZE(void *actual, void *expected,
 		return ;
 	}
 		
-	if (malloc_size(actual) != malloc_size(expected))
+	if (MALLOC_SIZE(actual) != MALLOC_SIZE(expected))
 	{
 		print_ko();
-		print_error("[test %zu] %s failed: malloc_size \"%i\" is not equal to expected \"%i\"\n", counter, __func__, malloc_size(actual), malloc_size(expected));
+		print_error("[test %zu] %s failed: malloc_size \"%i\" is not equal to expected \"%i\"\n", counter, __func__, MALLOC_SIZE(actual), MALLOC_SIZE(expected));
 		print_error("func %s at file %s, line %d\n",
 			caller_func, caller_file, caller_line);
 	}

--- a/srcs/test_ft_isalnum.c
+++ b/srcs/test_ft_isalnum.c
@@ -39,8 +39,8 @@ int	main(void)
 	/* 23 */ ASSERT_EQ_I(ft_isalnum('{'), isalnum('}'));
 	/* 24 */ ASSERT_EQ_I(ft_isalnum('~'), isalnum('~'));
 	/* 25. zero */ ASSERT_EQ_I(ft_isalnum(0), isalnum(0));
-	// undefined: /* 26. INI_MAX */ ASSERT_EQ_I(ft_isalnum(INT_MAX), isalnum(INT_MAX));
-	// undefined: /* 27. INT_MIN */ ASSERT_EQ_I(ft_isalnum(INT_MIN), isalnum(INT_MIN));
+	/* 26. INT_MAX */ ASSERT_EQ_I(ft_isalnum(INT_MAX), isalnum(INT_MAX));
+	/* 27. INT_MIN */ ASSERT_EQ_I(ft_isalnum(INT_MIN), isalnum(INT_MIN));
 	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalnum(i), isalnum(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isalnum.c
+++ b/srcs/test_ft_isalnum.c
@@ -11,36 +11,52 @@
 /* ************************************************************************** */
 
 #include "tester.h"
+#ifdef __linux__
+#define OS_NAME "Linux"
+#else
+#define OS_NAME ""
+#endif
+
+int	test_isalnum(int c)
+{
+	if (strcmp(OS_NAME, "Linux") == 0)
+	{
+		if (isalnum(c) == 0)
+			return (0);
+		return (1);
+	}
+		return (isalnum(c));
+}
 
 int	main(void)
 {
-	/* 1 */ ASSERT_EQ_I(ft_isalnum('a'), isalnum('a'));
-	/* 2 */ ASSERT_EQ_I(ft_isalnum('a' - 1), isalnum('a' - 1));
-	/* 3 */ ASSERT_EQ_I(ft_isalnum('a' + 1), isalnum('a' + 1));
-	/* 4 */ ASSERT_EQ_I(ft_isalnum('z'), isalnum('z'));
-	/* 5 */ ASSERT_EQ_I(ft_isalnum('z' - 1), isalnum('z' - 1));
-	/* 6 */ ASSERT_EQ_I(ft_isalnum('z' + 1), isalnum('z' + 1));
-	/* 7 */ ASSERT_EQ_I(ft_isalnum('A'), isalnum('A'));
-	/* 8 */ ASSERT_EQ_I(ft_isalnum('A' - 1), isalnum('A' - 1));
-	/* 9 */ ASSERT_EQ_I(ft_isalnum('A' + 1), isalnum('A' + 1));
-	/* 10 */ ASSERT_EQ_I(ft_isalnum('Z'), isalnum('Z'));
-	/* 11 */ ASSERT_EQ_I(ft_isalnum('Z' - 1), isalnum('Z' - 1));
-	/* 12 */ ASSERT_EQ_I(ft_isalnum('Z' + 1), isalnum('Z' + 1));
-	/* 13 */ ASSERT_EQ_I(ft_isalnum('a' + 256), isalnum('a' + 256));
-	/* 14 */ ASSERT_EQ_I(ft_isalnum('a' - 256), isalnum('a' - 256));
-	/* 15 */ ASSERT_EQ_I(ft_isalnum('a' + 1), isalnum('a' + 1));
-	/* 16 */ ASSERT_EQ_I(ft_isalnum('0'), isalnum('0'));
-	/* 17 */ ASSERT_EQ_I(ft_isalnum('0' - 1), isalnum('0' - 1));
-	/* 18 */ ASSERT_EQ_I(ft_isalnum('0' + 1), isalnum('0' + 1));
-	/* 19 */ ASSERT_EQ_I(ft_isalnum('9'), isalnum('9'));
-	/* 20 */ ASSERT_EQ_I(ft_isalnum('9' - 1), isalnum('9' - 1));
-	/* 21 */ ASSERT_EQ_I(ft_isalnum('9' + 1), isalnum('9' + 1));
-	/* 22 */ ASSERT_EQ_I(ft_isalnum('!'), isalnum('!'));
-	/* 23 */ ASSERT_EQ_I(ft_isalnum('{'), isalnum('}'));
-	/* 24 */ ASSERT_EQ_I(ft_isalnum('~'), isalnum('~'));
-	/* 25. zero */ ASSERT_EQ_I(ft_isalnum(0), isalnum(0));
-	/* 26. INI_MAX */ ASSERT_EQ_I(ft_isalnum(INT_MAX), isalnum(INT_MAX));
-	/* 27. INT_MIN */ ASSERT_EQ_I(ft_isalnum(INT_MIN), isalnum(INT_MIN));
-	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalnum(i), isalnum(i)); }
+	/* 1 */ ASSERT_EQ_I(ft_isalnum('a'), test_isalnum('a'));
+	/* 2 */ ASSERT_EQ_I(ft_isalnum('a' - 1), test_isalnum('a' - 1));
+	/* 3 */ ASSERT_EQ_I(ft_isalnum('a' + 1), test_isalnum('a' + 1));
+	/* 4 */ ASSERT_EQ_I(ft_isalnum('z'), test_isalnum('z'));
+	/* 5 */ ASSERT_EQ_I(ft_isalnum('z' - 1), test_isalnum('z' - 1));
+	/* 6 */ ASSERT_EQ_I(ft_isalnum('z' + 1), test_isalnum('z' + 1));
+	/* 7 */ ASSERT_EQ_I(ft_isalnum('A'), test_isalnum('A'));
+	/* 8 */ ASSERT_EQ_I(ft_isalnum('A' - 1), test_isalnum('A' - 1));
+	/* 9 */ ASSERT_EQ_I(ft_isalnum('A' + 1), test_isalnum('A' + 1));
+	/* 10 */ ASSERT_EQ_I(ft_isalnum('Z'), test_isalnum('Z'));
+	/* 11 */ ASSERT_EQ_I(ft_isalnum('Z' - 1), test_isalnum('Z' - 1));
+	/* 12 */ ASSERT_EQ_I(ft_isalnum('Z' + 1), test_isalnum('Z' + 1));
+	/* 13 */ ASSERT_EQ_I(ft_isalnum('a' + 256), test_isalnum('a' + 256));
+	/* 14 */ ASSERT_EQ_I(ft_isalnum('a' - 256), test_isalnum('a' - 256));
+	/* 15 */ ASSERT_EQ_I(ft_isalnum('a' + 1), test_isalnum('a' + 1));
+	/* 16 */ ASSERT_EQ_I(ft_isalnum('0'), test_isalnum('0'));
+	/* 17 */ ASSERT_EQ_I(ft_isalnum('0' - 1), test_isalnum('0' - 1));
+	/* 18 */ ASSERT_EQ_I(ft_isalnum('0' + 1), test_isalnum('0' + 1));
+	/* 19 */ ASSERT_EQ_I(ft_isalnum('9'), test_isalnum('9'));
+	/* 20 */ ASSERT_EQ_I(ft_isalnum('9' - 1), test_isalnum('9' - 1));
+	/* 21 */ ASSERT_EQ_I(ft_isalnum('9' + 1), test_isalnum('9' + 1));
+	/* 22 */ ASSERT_EQ_I(ft_isalnum('!'), test_isalnum('!'));
+	/* 23 */ ASSERT_EQ_I(ft_isalnum('{'), test_isalnum('}'));
+	/* 24 */ ASSERT_EQ_I(ft_isalnum('~'), test_isalnum('~'));
+	/* 25. zero */ ASSERT_EQ_I(ft_isalnum(0), test_isalnum(0));
+	// undefined: /* 26. INI_MAX */ ASSERT_EQ_I(ft_isalnum(INT_MAX), test_isalnum(INT_MAX));
+	// undefined: /* 27. INT_MIN */ ASSERT_EQ_I(ft_isalnum(INT_MIN), test_isalnum(INT_MIN));
+	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalnum(i), test_isalnum(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isalnum.c
+++ b/srcs/test_ft_isalnum.c
@@ -11,6 +11,13 @@
 /* ************************************************************************** */
 
 #include "tester.h"
+#ifdef __linux__
+# define LIMIT_MAX 216607
+# define LIMIT_MIN -915936
+#else
+# define LIMIT_MAX INT_MAX
+# define LIMIT_MIN INT_MIN
+#endif
 
 int	main(void)
 {
@@ -39,8 +46,8 @@ int	main(void)
 	/* 23 */ ASSERT_EQ_I(ft_isalnum('{'), isalnum('}'));
 	/* 24 */ ASSERT_EQ_I(ft_isalnum('~'), isalnum('~'));
 	/* 25. zero */ ASSERT_EQ_I(ft_isalnum(0), isalnum(0));
-	/* 26. INT_MAX */ ASSERT_EQ_I(ft_isalnum(INT_MAX), isalnum(INT_MAX));
-	/* 27. INT_MIN */ ASSERT_EQ_I(ft_isalnum(INT_MIN), isalnum(INT_MIN));
+	/* 26. INT_MAX */ ASSERT_EQ_I(ft_isalnum(LIMIT_MAX), isalnum(LIMIT_MAX));
+	/* 27. INT_MIN */ ASSERT_EQ_I(ft_isalnum(LIMIT_MIN), isalnum(LIMIT_MIN));
 	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalnum(i), isalnum(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isalnum.c
+++ b/srcs/test_ft_isalnum.c
@@ -11,52 +11,36 @@
 /* ************************************************************************** */
 
 #include "tester.h"
-#ifdef __linux__
-#define OS_NAME "Linux"
-#else
-#define OS_NAME ""
-#endif
-
-int	test_isalnum(int c)
-{
-	if (strcmp(OS_NAME, "Linux") == 0)
-	{
-		if (isalnum(c) == 0)
-			return (0);
-		return (1);
-	}
-		return (isalnum(c));
-}
 
 int	main(void)
 {
-	/* 1 */ ASSERT_EQ_I(ft_isalnum('a'), test_isalnum('a'));
-	/* 2 */ ASSERT_EQ_I(ft_isalnum('a' - 1), test_isalnum('a' - 1));
-	/* 3 */ ASSERT_EQ_I(ft_isalnum('a' + 1), test_isalnum('a' + 1));
-	/* 4 */ ASSERT_EQ_I(ft_isalnum('z'), test_isalnum('z'));
-	/* 5 */ ASSERT_EQ_I(ft_isalnum('z' - 1), test_isalnum('z' - 1));
-	/* 6 */ ASSERT_EQ_I(ft_isalnum('z' + 1), test_isalnum('z' + 1));
-	/* 7 */ ASSERT_EQ_I(ft_isalnum('A'), test_isalnum('A'));
-	/* 8 */ ASSERT_EQ_I(ft_isalnum('A' - 1), test_isalnum('A' - 1));
-	/* 9 */ ASSERT_EQ_I(ft_isalnum('A' + 1), test_isalnum('A' + 1));
-	/* 10 */ ASSERT_EQ_I(ft_isalnum('Z'), test_isalnum('Z'));
-	/* 11 */ ASSERT_EQ_I(ft_isalnum('Z' - 1), test_isalnum('Z' - 1));
-	/* 12 */ ASSERT_EQ_I(ft_isalnum('Z' + 1), test_isalnum('Z' + 1));
-	/* 13 */ ASSERT_EQ_I(ft_isalnum('a' + 256), test_isalnum('a' + 256));
-	/* 14 */ ASSERT_EQ_I(ft_isalnum('a' - 256), test_isalnum('a' - 256));
-	/* 15 */ ASSERT_EQ_I(ft_isalnum('a' + 1), test_isalnum('a' + 1));
-	/* 16 */ ASSERT_EQ_I(ft_isalnum('0'), test_isalnum('0'));
-	/* 17 */ ASSERT_EQ_I(ft_isalnum('0' - 1), test_isalnum('0' - 1));
-	/* 18 */ ASSERT_EQ_I(ft_isalnum('0' + 1), test_isalnum('0' + 1));
-	/* 19 */ ASSERT_EQ_I(ft_isalnum('9'), test_isalnum('9'));
-	/* 20 */ ASSERT_EQ_I(ft_isalnum('9' - 1), test_isalnum('9' - 1));
-	/* 21 */ ASSERT_EQ_I(ft_isalnum('9' + 1), test_isalnum('9' + 1));
-	/* 22 */ ASSERT_EQ_I(ft_isalnum('!'), test_isalnum('!'));
-	/* 23 */ ASSERT_EQ_I(ft_isalnum('{'), test_isalnum('}'));
-	/* 24 */ ASSERT_EQ_I(ft_isalnum('~'), test_isalnum('~'));
-	/* 25. zero */ ASSERT_EQ_I(ft_isalnum(0), test_isalnum(0));
-	// undefined: /* 26. INI_MAX */ ASSERT_EQ_I(ft_isalnum(INT_MAX), test_isalnum(INT_MAX));
-	// undefined: /* 27. INT_MIN */ ASSERT_EQ_I(ft_isalnum(INT_MIN), test_isalnum(INT_MIN));
-	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalnum(i), test_isalnum(i)); }
+	/* 1 */ ASSERT_EQ_I(ft_isalnum('a'), isalnum('a'));
+	/* 2 */ ASSERT_EQ_I(ft_isalnum('a' - 1), isalnum('a' - 1));
+	/* 3 */ ASSERT_EQ_I(ft_isalnum('a' + 1), isalnum('a' + 1));
+	/* 4 */ ASSERT_EQ_I(ft_isalnum('z'), isalnum('z'));
+	/* 5 */ ASSERT_EQ_I(ft_isalnum('z' - 1), isalnum('z' - 1));
+	/* 6 */ ASSERT_EQ_I(ft_isalnum('z' + 1), isalnum('z' + 1));
+	/* 7 */ ASSERT_EQ_I(ft_isalnum('A'), isalnum('A'));
+	/* 8 */ ASSERT_EQ_I(ft_isalnum('A' - 1), isalnum('A' - 1));
+	/* 9 */ ASSERT_EQ_I(ft_isalnum('A' + 1), isalnum('A' + 1));
+	/* 10 */ ASSERT_EQ_I(ft_isalnum('Z'), isalnum('Z'));
+	/* 11 */ ASSERT_EQ_I(ft_isalnum('Z' - 1), isalnum('Z' - 1));
+	/* 12 */ ASSERT_EQ_I(ft_isalnum('Z' + 1), isalnum('Z' + 1));
+	/* 13 */ ASSERT_EQ_I(ft_isalnum('a' + 256), isalnum('a' + 256));
+	/* 14 */ ASSERT_EQ_I(ft_isalnum('a' - 256), isalnum('a' - 256));
+	/* 15 */ ASSERT_EQ_I(ft_isalnum('a' + 1), isalnum('a' + 1));
+	/* 16 */ ASSERT_EQ_I(ft_isalnum('0'), isalnum('0'));
+	/* 17 */ ASSERT_EQ_I(ft_isalnum('0' - 1), isalnum('0' - 1));
+	/* 18 */ ASSERT_EQ_I(ft_isalnum('0' + 1), isalnum('0' + 1));
+	/* 19 */ ASSERT_EQ_I(ft_isalnum('9'), isalnum('9'));
+	/* 20 */ ASSERT_EQ_I(ft_isalnum('9' - 1), isalnum('9' - 1));
+	/* 21 */ ASSERT_EQ_I(ft_isalnum('9' + 1), isalnum('9' + 1));
+	/* 22 */ ASSERT_EQ_I(ft_isalnum('!'), isalnum('!'));
+	/* 23 */ ASSERT_EQ_I(ft_isalnum('{'), isalnum('}'));
+	/* 24 */ ASSERT_EQ_I(ft_isalnum('~'), isalnum('~'));
+	/* 25. zero */ ASSERT_EQ_I(ft_isalnum(0), isalnum(0));
+	// undefined: /* 26. INI_MAX */ ASSERT_EQ_I(ft_isalnum(INT_MAX), isalnum(INT_MAX));
+	// undefined: /* 27. INT_MIN */ ASSERT_EQ_I(ft_isalnum(INT_MIN), isalnum(INT_MIN));
+	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalnum(i), isalnum(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isalpha.c
+++ b/srcs/test_ft_isalpha.c
@@ -11,46 +11,30 @@
 /* ************************************************************************** */
 
 #include "tester.h"
-#ifdef __linux__
-#define OS_NAME "Linux"
-#else
-#define OS_NAME ""
-#endif
-
-int	test_isalpha(int c)
-{
-	if (strcmp(OS_NAME, "Linux") == 0)
-	{
-		if (isalpha(c) == 0)
-			return (0);
-		return (1);
-	}
-		return (isalpha(c));
-}
 
 int	main(void)
 {
-	/* 1 */ ASSERT_EQ_I(ft_isalpha('a'), test_isalpha('b'));
-	/* 2 */ ASSERT_EQ_I(ft_isalpha('a' - 1), test_isalpha('a' - 1));
-	/* 3 */ ASSERT_EQ_I(ft_isalpha('a' + 1), test_isalpha('a' + 1));
-	/* 4 */ ASSERT_EQ_I(ft_isalpha('z'), test_isalpha('z'));
-	/* 5 */ ASSERT_EQ_I(ft_isalpha('z' - 1), test_isalpha('z' - 1));
-	/* 6 */ ASSERT_EQ_I(ft_isalpha('z' + 1), test_isalpha('z' + 1));
-	/* 7 */ ASSERT_EQ_I(ft_isalpha('A'), test_isalpha('A'));
-	/* 8 */ ASSERT_EQ_I(ft_isalpha('A' - 1), test_isalpha('A' - 1));
-	/* 9 */ ASSERT_EQ_I(ft_isalpha('A' + 1), test_isalpha('A' + 1));
-	/* 10 */ ASSERT_EQ_I(ft_isalpha('Z'), test_isalpha('Z'));
-	/* 11 */ ASSERT_EQ_I(ft_isalpha('Z' - 1), test_isalpha('Z' - 1));
-	/* 12 */ ASSERT_EQ_I(ft_isalpha('Z' + 1), test_isalpha('Z' + 1));
-	/* 13 */ ASSERT_EQ_I(ft_isalpha('a' + 256), test_isalpha('a' + 256));
-	/* 14 */ ASSERT_EQ_I(ft_isalpha('a' - 256), test_isalpha('a' - 256));
-	/* 15 */ ASSERT_EQ_I(ft_isalpha('a' + 1), test_isalpha('a' + 1));
-	/* 16 */ ASSERT_EQ_I(ft_isalpha('!'), test_isalpha('!'));
-	/* 17 */ ASSERT_EQ_I(ft_isalpha('{'), test_isalpha('}'));
-	/* 18 */ ASSERT_EQ_I(ft_isalpha('~'), test_isalpha('~'));
-	/* 19. zero */ ASSERT_EQ_I(ft_isalpha(0), test_isalpha(0));
-	// undefined: /* 20. INI_MAX */ ASSERT_EQ_I(ft_isalpha(INT_MAX), test_isalpha(INT_MAX));
-	// undefined: /* 21. INT_MIN */ ASSERT_EQ_I(ft_isalpha(INT_MIN), test_isalpha(INT_MIN));
-	/* 22 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalpha(i), test_isalpha(i)); }
+	/* 1 */ ASSERT_EQ_I(ft_isalpha('a'), isalpha('b'));
+	/* 2 */ ASSERT_EQ_I(ft_isalpha('a' - 1), isalpha('a' - 1));
+	/* 3 */ ASSERT_EQ_I(ft_isalpha('a' + 1), isalpha('a' + 1));
+	/* 4 */ ASSERT_EQ_I(ft_isalpha('z'), isalpha('z'));
+	/* 5 */ ASSERT_EQ_I(ft_isalpha('z' - 1), isalpha('z' - 1));
+	/* 6 */ ASSERT_EQ_I(ft_isalpha('z' + 1), isalpha('z' + 1));
+	/* 7 */ ASSERT_EQ_I(ft_isalpha('A'), isalpha('A'));
+	/* 8 */ ASSERT_EQ_I(ft_isalpha('A' - 1), isalpha('A' - 1));
+	/* 9 */ ASSERT_EQ_I(ft_isalpha('A' + 1), isalpha('A' + 1));
+	/* 10 */ ASSERT_EQ_I(ft_isalpha('Z'), isalpha('Z'));
+	/* 11 */ ASSERT_EQ_I(ft_isalpha('Z' - 1), isalpha('Z' - 1));
+	/* 12 */ ASSERT_EQ_I(ft_isalpha('Z' + 1), isalpha('Z' + 1));
+	/* 13 */ ASSERT_EQ_I(ft_isalpha('a' + 256), isalpha('a' + 256));
+	/* 14 */ ASSERT_EQ_I(ft_isalpha('a' - 256), isalpha('a' - 256));
+	/* 15 */ ASSERT_EQ_I(ft_isalpha('a' + 1), isalpha('a' + 1));
+	/* 16 */ ASSERT_EQ_I(ft_isalpha('!'), isalpha('!'));
+	/* 17 */ ASSERT_EQ_I(ft_isalpha('{'), isalpha('}'));
+	/* 18 */ ASSERT_EQ_I(ft_isalpha('~'), isalpha('~'));
+	/* 19. zero */ ASSERT_EQ_I(ft_isalpha(0), isalpha(0));
+	// undefined: /* 20. INI_MAX */ ASSERT_EQ_I(ft_isalpha(INT_MAX), isalpha(INT_MAX));
+	// undefined: /* 21. INT_MIN */ ASSERT_EQ_I(ft_isalpha(INT_MIN), isalpha(INT_MIN));
+	/* 22 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalpha(i), isalpha(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isalpha.c
+++ b/srcs/test_ft_isalpha.c
@@ -11,30 +11,46 @@
 /* ************************************************************************** */
 
 #include "tester.h"
+#ifdef __linux__
+#define OS_NAME "Linux"
+#else
+#define OS_NAME ""
+#endif
+
+int	test_isalpha(int c)
+{
+	if (strcmp(OS_NAME, "Linux") == 0)
+	{
+		if (isalpha(c) == 0)
+			return (0);
+		return (1);
+	}
+		return (isalpha(c));
+}
 
 int	main(void)
 {
-	/* 1 */ ASSERT_EQ_I(ft_isalpha('a'), isalpha('b'));
-	/* 2 */ ASSERT_EQ_I(ft_isalpha('a' - 1), isalpha('a' - 1));
-	/* 3 */ ASSERT_EQ_I(ft_isalpha('a' + 1), isalpha('a' + 1));
-	/* 4 */ ASSERT_EQ_I(ft_isalpha('z'), isalpha('z'));
-	/* 5 */ ASSERT_EQ_I(ft_isalpha('z' - 1), isalpha('z' - 1));
-	/* 6 */ ASSERT_EQ_I(ft_isalpha('z' + 1), isalpha('z' + 1));
-	/* 7 */ ASSERT_EQ_I(ft_isalpha('A'), isalpha('A'));
-	/* 8 */ ASSERT_EQ_I(ft_isalpha('A' - 1), isalpha('A' - 1));
-	/* 9 */ ASSERT_EQ_I(ft_isalpha('A' + 1), isalpha('A' + 1));
-	/* 10 */ ASSERT_EQ_I(ft_isalpha('Z'), isalpha('Z'));
-	/* 11 */ ASSERT_EQ_I(ft_isalpha('Z' - 1), isalpha('Z' - 1));
-	/* 12 */ ASSERT_EQ_I(ft_isalpha('Z' + 1), isalpha('Z' + 1));
-	/* 13 */ ASSERT_EQ_I(ft_isalpha('a' + 256), isalpha('a' + 256));
-	/* 14 */ ASSERT_EQ_I(ft_isalpha('a' - 256), isalpha('a' - 256));
-	/* 15 */ ASSERT_EQ_I(ft_isalpha('a' + 1), isalpha('a' + 1));
-	/* 16 */ ASSERT_EQ_I(ft_isalpha('!'), isalpha('!'));
-	/* 17 */ ASSERT_EQ_I(ft_isalpha('{'), isalpha('}'));
-	/* 18 */ ASSERT_EQ_I(ft_isalpha('~'), isalpha('~'));
-	/* 19. zero */ ASSERT_EQ_I(ft_isalpha(0), isalpha(0));
-	/* 20. INI_MAX */ ASSERT_EQ_I(ft_isalpha(INT_MAX), isalpha(INT_MAX));
-	/* 21. INT_MIN */ ASSERT_EQ_I(ft_isalpha(INT_MIN), isalpha(INT_MIN));
-	/* 22 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalpha(i), isalpha(i)); }
+	/* 1 */ ASSERT_EQ_I(ft_isalpha('a'), test_isalpha('b'));
+	/* 2 */ ASSERT_EQ_I(ft_isalpha('a' - 1), test_isalpha('a' - 1));
+	/* 3 */ ASSERT_EQ_I(ft_isalpha('a' + 1), test_isalpha('a' + 1));
+	/* 4 */ ASSERT_EQ_I(ft_isalpha('z'), test_isalpha('z'));
+	/* 5 */ ASSERT_EQ_I(ft_isalpha('z' - 1), test_isalpha('z' - 1));
+	/* 6 */ ASSERT_EQ_I(ft_isalpha('z' + 1), test_isalpha('z' + 1));
+	/* 7 */ ASSERT_EQ_I(ft_isalpha('A'), test_isalpha('A'));
+	/* 8 */ ASSERT_EQ_I(ft_isalpha('A' - 1), test_isalpha('A' - 1));
+	/* 9 */ ASSERT_EQ_I(ft_isalpha('A' + 1), test_isalpha('A' + 1));
+	/* 10 */ ASSERT_EQ_I(ft_isalpha('Z'), test_isalpha('Z'));
+	/* 11 */ ASSERT_EQ_I(ft_isalpha('Z' - 1), test_isalpha('Z' - 1));
+	/* 12 */ ASSERT_EQ_I(ft_isalpha('Z' + 1), test_isalpha('Z' + 1));
+	/* 13 */ ASSERT_EQ_I(ft_isalpha('a' + 256), test_isalpha('a' + 256));
+	/* 14 */ ASSERT_EQ_I(ft_isalpha('a' - 256), test_isalpha('a' - 256));
+	/* 15 */ ASSERT_EQ_I(ft_isalpha('a' + 1), test_isalpha('a' + 1));
+	/* 16 */ ASSERT_EQ_I(ft_isalpha('!'), test_isalpha('!'));
+	/* 17 */ ASSERT_EQ_I(ft_isalpha('{'), test_isalpha('}'));
+	/* 18 */ ASSERT_EQ_I(ft_isalpha('~'), test_isalpha('~'));
+	/* 19. zero */ ASSERT_EQ_I(ft_isalpha(0), test_isalpha(0));
+	// undefined: /* 20. INI_MAX */ ASSERT_EQ_I(ft_isalpha(INT_MAX), test_isalpha(INT_MAX));
+	// undefined: /* 21. INT_MIN */ ASSERT_EQ_I(ft_isalpha(INT_MIN), test_isalpha(INT_MIN));
+	/* 22 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalpha(i), test_isalpha(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isalpha.c
+++ b/srcs/test_ft_isalpha.c
@@ -11,6 +11,13 @@
 /* ************************************************************************** */
 
 #include "tester.h"
+#ifdef __linux__
+# define LIMIT_MAX 216607
+# define LIMIT_MIN -915936
+#else
+# define LIMIT_MAX INT_MAX
+# define LIMIT_MIN INT_MIN
+#endif
 
 int	main(void)
 {
@@ -33,8 +40,8 @@ int	main(void)
 	/* 17 */ ASSERT_EQ_I(ft_isalpha('{'), isalpha('}'));
 	/* 18 */ ASSERT_EQ_I(ft_isalpha('~'), isalpha('~'));
 	/* 19. zero */ ASSERT_EQ_I(ft_isalpha(0), isalpha(0));
-	/* 20. INT_MAX */ ASSERT_EQ_I(ft_isalpha(INT_MAX), isalpha(INT_MAX));
-	/* 21. INT_MIN */ ASSERT_EQ_I(ft_isalpha(INT_MIN), isalpha(INT_MIN));
+	/* 20. INT_MAX */ ASSERT_EQ_I(ft_isalpha(LIMIT_MAX), ft_isalpha(LIMIT_MAX));
+	/* 21. INT_MIN */ ASSERT_EQ_I(ft_isalpha(LIMIT_MIN), isalpha(LIMIT_MIN));
 	/* 22 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalpha(i), isalpha(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isalpha.c
+++ b/srcs/test_ft_isalpha.c
@@ -33,8 +33,8 @@ int	main(void)
 	/* 17 */ ASSERT_EQ_I(ft_isalpha('{'), isalpha('}'));
 	/* 18 */ ASSERT_EQ_I(ft_isalpha('~'), isalpha('~'));
 	/* 19. zero */ ASSERT_EQ_I(ft_isalpha(0), isalpha(0));
-	// undefined: /* 20. INI_MAX */ ASSERT_EQ_I(ft_isalpha(INT_MAX), isalpha(INT_MAX));
-	// undefined: /* 21. INT_MIN */ ASSERT_EQ_I(ft_isalpha(INT_MIN), isalpha(INT_MIN));
+	/* 20. INT_MAX */ ASSERT_EQ_I(ft_isalpha(INT_MAX), isalpha(INT_MAX));
+	/* 21. INT_MIN */ ASSERT_EQ_I(ft_isalpha(INT_MIN), isalpha(INT_MIN));
 	/* 22 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isalpha(i), isalpha(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isdigit.c
+++ b/srcs/test_ft_isdigit.c
@@ -11,21 +11,37 @@
 /* ************************************************************************** */
 
 #include "tester.h"
+#ifdef __linux__
+#define OS_NAME "Linux"
+#else
+#define OS_NAME ""
+#endif
+
+int	test_isdigit(int c)
+{
+	if (strcmp(OS_NAME, "Linux") == 0)
+	{
+		if (isdigit(c) == 0)
+			return (0);
+		return (1);
+	}
+		return (isdigit(c));
+}
 
 int	main(void)
 {
-	/* 1 */ ASSERT_EQ_I(ft_isdigit('0'), isdigit('0'));
-	/* 2 */ ASSERT_EQ_I(ft_isdigit('0' - 1), isdigit('0' - 1));
-	/* 3 */ ASSERT_EQ_I(ft_isdigit('0' + 1), isdigit('0' + 1));
-	/* 4 */ ASSERT_EQ_I(ft_isdigit('9'), isdigit('9'));
-	/* 5 */ ASSERT_EQ_I(ft_isdigit('9' - 1), isdigit('9' - 1));
-	/* 6 */ ASSERT_EQ_I(ft_isdigit('9' + 1), isdigit('9' + 1));
-	/* 7 */ ASSERT_EQ_I(ft_isdigit('!'), isdigit('!'));
-	/* 8 */ ASSERT_EQ_I(ft_isdigit('{'), isdigit('}'));
-	/* 9 */ ASSERT_EQ_I(ft_isdigit('~'), isdigit('~'));
-	/* 10. zero */ ASSERT_EQ_I(ft_isdigit(0), isdigit(0));
-	/* 11. INI_MAX */ ASSERT_EQ_I(ft_isdigit(INT_MAX), isdigit(INT_MAX));
-	/* 12. INT_MIN */ ASSERT_EQ_I(ft_isdigit(INT_MIN), isdigit(INT_MIN));
-	/* 13 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isdigit(i), isdigit(i)); }
+	/* 1 */ ASSERT_EQ_I(ft_isdigit('0'), test_isdigit('0'));
+	/* 2 */ ASSERT_EQ_I(ft_isdigit('0' - 1), test_isdigit('0' - 1));
+	/* 3 */ ASSERT_EQ_I(ft_isdigit('0' + 1), test_isdigit('0' + 1));
+	/* 4 */ ASSERT_EQ_I(ft_isdigit('9'), test_isdigit('9'));
+	/* 5 */ ASSERT_EQ_I(ft_isdigit('9' - 1), test_isdigit('9' - 1));
+	/* 6 */ ASSERT_EQ_I(ft_isdigit('9' + 1), test_isdigit('9' + 1));
+	/* 7 */ ASSERT_EQ_I(ft_isdigit('!'), test_isdigit('!'));
+	/* 8 */ ASSERT_EQ_I(ft_isdigit('{'), test_isdigit('}'));
+	/* 9 */ ASSERT_EQ_I(ft_isdigit('~'), test_isdigit('~'));
+	/* 10. zero */ ASSERT_EQ_I(ft_isdigit(0), test_isdigit(0));
+	// undefined: /* 11. INI_MAX */ ASSERT_EQ_I(ft_isdigit(INT_MAX), test_isdigit(INT_MAX));
+	// undefined: /* 12. INT_MIN */ ASSERT_EQ_I(ft_isdigit(INT_MIN), test_isdigit(INT_MIN));
+	/* 13 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isdigit(i), test_isdigit(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isdigit.c
+++ b/srcs/test_ft_isdigit.c
@@ -11,6 +11,13 @@
 /* ************************************************************************** */
 
 #include "tester.h"
+#ifdef __linux__
+# define LIMIT_MAX 216607
+# define LIMIT_MIN -915936
+#else
+# define LIMIT_MAX INT_MAX
+# define LIMIT_MIN INT_MIN
+#endif
 
 int	main(void)
 {
@@ -24,8 +31,8 @@ int	main(void)
 	/* 8 */ ASSERT_EQ_I(ft_isdigit('{'), isdigit('}'));
 	/* 9 */ ASSERT_EQ_I(ft_isdigit('~'), isdigit('~'));
 	/* 10. zero */ ASSERT_EQ_I(ft_isdigit(0), isdigit(0));
-	/* 11. INT_MAX */ ASSERT_EQ_I(ft_isdigit(INT_MAX), isdigit(INT_MAX));
-	/* 12. INT_MIN */ ASSERT_EQ_I(ft_isdigit(INT_MIN), isdigit(INT_MIN));
+	/* 11. INT_MAX */ ASSERT_EQ_I(ft_isdigit(LIMIT_MAX), isdigit(LIMIT_MAX));
+	/* 12. INT_MIN */ ASSERT_EQ_I(ft_isdigit(LIMIT_MIN), isdigit(LIMIT_MIN));
 	/* 13 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isdigit(i), isdigit(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isdigit.c
+++ b/srcs/test_ft_isdigit.c
@@ -24,8 +24,8 @@ int	main(void)
 	/* 8 */ ASSERT_EQ_I(ft_isdigit('{'), isdigit('}'));
 	/* 9 */ ASSERT_EQ_I(ft_isdigit('~'), isdigit('~'));
 	/* 10. zero */ ASSERT_EQ_I(ft_isdigit(0), isdigit(0));
-	// undefined: /* 11. INI_MAX */ ASSERT_EQ_I(ft_isdigit(INT_MAX), isdigit(INT_MAX));
-	// undefined: /* 12. INT_MIN */ ASSERT_EQ_I(ft_isdigit(INT_MIN), isdigit(INT_MIN));
+	/* 11. INT_MAX */ ASSERT_EQ_I(ft_isdigit(INT_MAX), isdigit(INT_MAX));
+	/* 12. INT_MIN */ ASSERT_EQ_I(ft_isdigit(INT_MIN), isdigit(INT_MIN));
 	/* 13 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isdigit(i), isdigit(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isdigit.c
+++ b/srcs/test_ft_isdigit.c
@@ -11,37 +11,21 @@
 /* ************************************************************************** */
 
 #include "tester.h"
-#ifdef __linux__
-#define OS_NAME "Linux"
-#else
-#define OS_NAME ""
-#endif
-
-int	test_isdigit(int c)
-{
-	if (strcmp(OS_NAME, "Linux") == 0)
-	{
-		if (isdigit(c) == 0)
-			return (0);
-		return (1);
-	}
-		return (isdigit(c));
-}
 
 int	main(void)
 {
-	/* 1 */ ASSERT_EQ_I(ft_isdigit('0'), test_isdigit('0'));
-	/* 2 */ ASSERT_EQ_I(ft_isdigit('0' - 1), test_isdigit('0' - 1));
-	/* 3 */ ASSERT_EQ_I(ft_isdigit('0' + 1), test_isdigit('0' + 1));
-	/* 4 */ ASSERT_EQ_I(ft_isdigit('9'), test_isdigit('9'));
-	/* 5 */ ASSERT_EQ_I(ft_isdigit('9' - 1), test_isdigit('9' - 1));
-	/* 6 */ ASSERT_EQ_I(ft_isdigit('9' + 1), test_isdigit('9' + 1));
-	/* 7 */ ASSERT_EQ_I(ft_isdigit('!'), test_isdigit('!'));
-	/* 8 */ ASSERT_EQ_I(ft_isdigit('{'), test_isdigit('}'));
-	/* 9 */ ASSERT_EQ_I(ft_isdigit('~'), test_isdigit('~'));
-	/* 10. zero */ ASSERT_EQ_I(ft_isdigit(0), test_isdigit(0));
-	// undefined: /* 11. INI_MAX */ ASSERT_EQ_I(ft_isdigit(INT_MAX), test_isdigit(INT_MAX));
-	// undefined: /* 12. INT_MIN */ ASSERT_EQ_I(ft_isdigit(INT_MIN), test_isdigit(INT_MIN));
-	/* 13 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isdigit(i), test_isdigit(i)); }
+	/* 1 */ ASSERT_EQ_I(ft_isdigit('0'), isdigit('0'));
+	/* 2 */ ASSERT_EQ_I(ft_isdigit('0' - 1), isdigit('0' - 1));
+	/* 3 */ ASSERT_EQ_I(ft_isdigit('0' + 1), isdigit('0' + 1));
+	/* 4 */ ASSERT_EQ_I(ft_isdigit('9'), isdigit('9'));
+	/* 5 */ ASSERT_EQ_I(ft_isdigit('9' - 1), isdigit('9' - 1));
+	/* 6 */ ASSERT_EQ_I(ft_isdigit('9' + 1), isdigit('9' + 1));
+	/* 7 */ ASSERT_EQ_I(ft_isdigit('!'), isdigit('!'));
+	/* 8 */ ASSERT_EQ_I(ft_isdigit('{'), isdigit('}'));
+	/* 9 */ ASSERT_EQ_I(ft_isdigit('~'), isdigit('~'));
+	/* 10. zero */ ASSERT_EQ_I(ft_isdigit(0), isdigit(0));
+	// undefined: /* 11. INI_MAX */ ASSERT_EQ_I(ft_isdigit(INT_MAX), isdigit(INT_MAX));
+	// undefined: /* 12. INT_MIN */ ASSERT_EQ_I(ft_isdigit(INT_MIN), isdigit(INT_MIN));
+	/* 13 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isdigit(i), isdigit(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isprint.c
+++ b/srcs/test_ft_isprint.c
@@ -11,36 +11,52 @@
 /* ************************************************************************** */
 
 #include "tester.h"
+#ifdef __linux__
+#define OS_NAME "Linux"
+#else
+#define OS_NAME ""
+#endif
+
+int	test_isprint(int c)
+{
+	if (strcmp(OS_NAME, "Linux") == 0)
+	{
+		if (isprint(c) == 0)
+			return (0);
+		return (1);
+	}
+		return (isprint(c));
+}
 
 int	main(void)
 {
-	/* 1 */ ASSERT_EQ_I(ft_isprint('a'), isprint('a'));
-	/* 2 */ ASSERT_EQ_I(ft_isprint('a' - 1), isprint('a' - 1));
-	/* 3 */ ASSERT_EQ_I(ft_isprint('a' + 1), isprint('a' + 1));
-	/* 4 */ ASSERT_EQ_I(ft_isprint('z'), isprint('z'));
-	/* 5 */ ASSERT_EQ_I(ft_isprint('z' - 1), isprint('z' - 1));
-	/* 6 */ ASSERT_EQ_I(ft_isprint('z' + 1), isprint('z' + 1));
-	/* 7 */ ASSERT_EQ_I(ft_isprint('A'), isprint('A'));
-	/* 8 */ ASSERT_EQ_I(ft_isprint('A' - 1), isprint('A' - 1));
-	/* 9 */ ASSERT_EQ_I(ft_isprint('A' + 1), isprint('A' + 1));
-	/* 10 */ ASSERT_EQ_I(ft_isprint('Z'), isprint('Z'));
-	/* 11 */ ASSERT_EQ_I(ft_isprint('Z' - 1), isprint('Z' - 1));
-	/* 12 */ ASSERT_EQ_I(ft_isprint('Z' + 1), isprint('Z' + 1));
-	/* 13 */ ASSERT_EQ_I(ft_isprint('a' + 256), isprint('a' + 256));
-	/* 14 */ ASSERT_EQ_I(ft_isprint('a' - 256), isprint('a' - 256));
-	/* 15 */ ASSERT_EQ_I(ft_isprint('a' + 1), isprint('a' + 1));
-	/* 16 */ ASSERT_EQ_I(ft_isprint('0'), isprint('0'));
-	/* 17 */ ASSERT_EQ_I(ft_isprint('0' - 1), isprint('0' - 1));
-	/* 18 */ ASSERT_EQ_I(ft_isprint('0' + 1), isprint('0' + 1));
-	/* 19 */ ASSERT_EQ_I(ft_isprint('9'), isprint('9'));
-	/* 20 */ ASSERT_EQ_I(ft_isprint('9' - 1), isprint('9' - 1));
-	/* 21 */ ASSERT_EQ_I(ft_isprint('9' + 1), isprint('9' + 1));
-	/* 22 */ ASSERT_EQ_I(ft_isprint('!'), isprint('!'));
-	/* 23 */ ASSERT_EQ_I(ft_isprint('{'), isprint('}'));
-	/* 24 */ ASSERT_EQ_I(ft_isprint('~'), isprint('~'));
-	/* 25. zero */ ASSERT_EQ_I(ft_isprint(0), isprint(0));
-	/* 26. INI_MAX */ ASSERT_EQ_I(ft_isprint(INT_MAX), isprint(INT_MAX));
-	/* 27. INT_MIN */ ASSERT_EQ_I(ft_isprint(INT_MIN), isprint(INT_MIN));
-	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isprint(i), isprint(i)); }
+	/* 1 */ ASSERT_EQ_I(ft_isprint('a'), test_isprint('a'));
+	/* 2 */ ASSERT_EQ_I(ft_isprint('a' - 1), test_isprint('a' - 1));
+	/* 3 */ ASSERT_EQ_I(ft_isprint('a' + 1), test_isprint('a' + 1));
+	/* 4 */ ASSERT_EQ_I(ft_isprint('z'), test_isprint('z'));
+	/* 5 */ ASSERT_EQ_I(ft_isprint('z' - 1), test_isprint('z' - 1));
+	/* 6 */ ASSERT_EQ_I(ft_isprint('z' + 1), test_isprint('z' + 1));
+	/* 7 */ ASSERT_EQ_I(ft_isprint('A'), test_isprint('A'));
+	/* 8 */ ASSERT_EQ_I(ft_isprint('A' - 1), test_isprint('A' - 1));
+	/* 9 */ ASSERT_EQ_I(ft_isprint('A' + 1), test_isprint('A' + 1));
+	/* 10 */ ASSERT_EQ_I(ft_isprint('Z'), test_isprint('Z'));
+	/* 11 */ ASSERT_EQ_I(ft_isprint('Z' - 1), test_isprint('Z' - 1));
+	/* 12 */ ASSERT_EQ_I(ft_isprint('Z' + 1), test_isprint('Z' + 1));
+	/* 13 */ ASSERT_EQ_I(ft_isprint('a' + 256), test_isprint('a' + 256));
+	/* 14 */ ASSERT_EQ_I(ft_isprint('a' - 256), test_isprint('a' - 256));
+	/* 15 */ ASSERT_EQ_I(ft_isprint('a' + 1), test_isprint('a' + 1));
+	/* 16 */ ASSERT_EQ_I(ft_isprint('0'), test_isprint('0'));
+	/* 17 */ ASSERT_EQ_I(ft_isprint('0' - 1), test_isprint('0' - 1));
+	/* 18 */ ASSERT_EQ_I(ft_isprint('0' + 1), test_isprint('0' + 1));
+	/* 19 */ ASSERT_EQ_I(ft_isprint('9'), test_isprint('9'));
+	/* 20 */ ASSERT_EQ_I(ft_isprint('9' - 1), test_isprint('9' - 1));
+	/* 21 */ ASSERT_EQ_I(ft_isprint('9' + 1), test_isprint('9' + 1));
+	/* 22 */ ASSERT_EQ_I(ft_isprint('!'), test_isprint('!'));
+	/* 23 */ ASSERT_EQ_I(ft_isprint('{'), test_isprint('}'));
+	/* 24 */ ASSERT_EQ_I(ft_isprint('~'), test_isprint('~'));
+	/* 25. zero */ ASSERT_EQ_I(ft_isprint(0), test_isprint(0));
+	// undefined: /* 26. INI_MAX */ ASSERT_EQ_I(ft_isprint(INT_MAX), test_isprint(INT_MAX));
+	// undefined: /* 27. INT_MIN */ ASSERT_EQ_I(ft_isprint(INT_MIN), test_isprint(INT_MIN));
+	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isprint(i), test_isprint(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isprint.c
+++ b/srcs/test_ft_isprint.c
@@ -39,8 +39,8 @@ int	main(void)
 	/* 23 */ ASSERT_EQ_I(ft_isprint('{'), isprint('}'));
 	/* 24 */ ASSERT_EQ_I(ft_isprint('~'), isprint('~'));
 	/* 25. zero */ ASSERT_EQ_I(ft_isprint(0), isprint(0));
-	// undefined: /* 26. INI_MAX */ ASSERT_EQ_I(ft_isprint(INT_MAX), isprint(INT_MAX));
-	// undefined: /* 27. INT_MIN */ ASSERT_EQ_I(ft_isprint(INT_MIN), isprint(INT_MIN));
+	/* 26. INT_MAX */ ASSERT_EQ_I(ft_isprint(INT_MAX), isprint(INT_MAX));
+	/* 27. INT_MIN */ ASSERT_EQ_I(ft_isprint(INT_MIN), isprint(INT_MIN));
 	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isprint(i), isprint(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isprint.c
+++ b/srcs/test_ft_isprint.c
@@ -11,52 +11,36 @@
 /* ************************************************************************** */
 
 #include "tester.h"
-#ifdef __linux__
-#define OS_NAME "Linux"
-#else
-#define OS_NAME ""
-#endif
-
-int	test_isprint(int c)
-{
-	if (strcmp(OS_NAME, "Linux") == 0)
-	{
-		if (isprint(c) == 0)
-			return (0);
-		return (1);
-	}
-		return (isprint(c));
-}
 
 int	main(void)
 {
-	/* 1 */ ASSERT_EQ_I(ft_isprint('a'), test_isprint('a'));
-	/* 2 */ ASSERT_EQ_I(ft_isprint('a' - 1), test_isprint('a' - 1));
-	/* 3 */ ASSERT_EQ_I(ft_isprint('a' + 1), test_isprint('a' + 1));
-	/* 4 */ ASSERT_EQ_I(ft_isprint('z'), test_isprint('z'));
-	/* 5 */ ASSERT_EQ_I(ft_isprint('z' - 1), test_isprint('z' - 1));
-	/* 6 */ ASSERT_EQ_I(ft_isprint('z' + 1), test_isprint('z' + 1));
-	/* 7 */ ASSERT_EQ_I(ft_isprint('A'), test_isprint('A'));
-	/* 8 */ ASSERT_EQ_I(ft_isprint('A' - 1), test_isprint('A' - 1));
-	/* 9 */ ASSERT_EQ_I(ft_isprint('A' + 1), test_isprint('A' + 1));
-	/* 10 */ ASSERT_EQ_I(ft_isprint('Z'), test_isprint('Z'));
-	/* 11 */ ASSERT_EQ_I(ft_isprint('Z' - 1), test_isprint('Z' - 1));
-	/* 12 */ ASSERT_EQ_I(ft_isprint('Z' + 1), test_isprint('Z' + 1));
-	/* 13 */ ASSERT_EQ_I(ft_isprint('a' + 256), test_isprint('a' + 256));
-	/* 14 */ ASSERT_EQ_I(ft_isprint('a' - 256), test_isprint('a' - 256));
-	/* 15 */ ASSERT_EQ_I(ft_isprint('a' + 1), test_isprint('a' + 1));
-	/* 16 */ ASSERT_EQ_I(ft_isprint('0'), test_isprint('0'));
-	/* 17 */ ASSERT_EQ_I(ft_isprint('0' - 1), test_isprint('0' - 1));
-	/* 18 */ ASSERT_EQ_I(ft_isprint('0' + 1), test_isprint('0' + 1));
-	/* 19 */ ASSERT_EQ_I(ft_isprint('9'), test_isprint('9'));
-	/* 20 */ ASSERT_EQ_I(ft_isprint('9' - 1), test_isprint('9' - 1));
-	/* 21 */ ASSERT_EQ_I(ft_isprint('9' + 1), test_isprint('9' + 1));
-	/* 22 */ ASSERT_EQ_I(ft_isprint('!'), test_isprint('!'));
-	/* 23 */ ASSERT_EQ_I(ft_isprint('{'), test_isprint('}'));
-	/* 24 */ ASSERT_EQ_I(ft_isprint('~'), test_isprint('~'));
-	/* 25. zero */ ASSERT_EQ_I(ft_isprint(0), test_isprint(0));
-	// undefined: /* 26. INI_MAX */ ASSERT_EQ_I(ft_isprint(INT_MAX), test_isprint(INT_MAX));
-	// undefined: /* 27. INT_MIN */ ASSERT_EQ_I(ft_isprint(INT_MIN), test_isprint(INT_MIN));
-	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isprint(i), test_isprint(i)); }
+	/* 1 */ ASSERT_EQ_I(ft_isprint('a'), isprint('a'));
+	/* 2 */ ASSERT_EQ_I(ft_isprint('a' - 1), isprint('a' - 1));
+	/* 3 */ ASSERT_EQ_I(ft_isprint('a' + 1), isprint('a' + 1));
+	/* 4 */ ASSERT_EQ_I(ft_isprint('z'), isprint('z'));
+	/* 5 */ ASSERT_EQ_I(ft_isprint('z' - 1), isprint('z' - 1));
+	/* 6 */ ASSERT_EQ_I(ft_isprint('z' + 1), isprint('z' + 1));
+	/* 7 */ ASSERT_EQ_I(ft_isprint('A'), isprint('A'));
+	/* 8 */ ASSERT_EQ_I(ft_isprint('A' - 1), isprint('A' - 1));
+	/* 9 */ ASSERT_EQ_I(ft_isprint('A' + 1), isprint('A' + 1));
+	/* 10 */ ASSERT_EQ_I(ft_isprint('Z'), isprint('Z'));
+	/* 11 */ ASSERT_EQ_I(ft_isprint('Z' - 1), isprint('Z' - 1));
+	/* 12 */ ASSERT_EQ_I(ft_isprint('Z' + 1), isprint('Z' + 1));
+	/* 13 */ ASSERT_EQ_I(ft_isprint('a' + 256), isprint('a' + 256));
+	/* 14 */ ASSERT_EQ_I(ft_isprint('a' - 256), isprint('a' - 256));
+	/* 15 */ ASSERT_EQ_I(ft_isprint('a' + 1), isprint('a' + 1));
+	/* 16 */ ASSERT_EQ_I(ft_isprint('0'), isprint('0'));
+	/* 17 */ ASSERT_EQ_I(ft_isprint('0' - 1), isprint('0' - 1));
+	/* 18 */ ASSERT_EQ_I(ft_isprint('0' + 1), isprint('0' + 1));
+	/* 19 */ ASSERT_EQ_I(ft_isprint('9'), isprint('9'));
+	/* 20 */ ASSERT_EQ_I(ft_isprint('9' - 1), isprint('9' - 1));
+	/* 21 */ ASSERT_EQ_I(ft_isprint('9' + 1), isprint('9' + 1));
+	/* 22 */ ASSERT_EQ_I(ft_isprint('!'), isprint('!'));
+	/* 23 */ ASSERT_EQ_I(ft_isprint('{'), isprint('}'));
+	/* 24 */ ASSERT_EQ_I(ft_isprint('~'), isprint('~'));
+	/* 25. zero */ ASSERT_EQ_I(ft_isprint(0), isprint(0));
+	// undefined: /* 26. INI_MAX */ ASSERT_EQ_I(ft_isprint(INT_MAX), isprint(INT_MAX));
+	// undefined: /* 27. INT_MIN */ ASSERT_EQ_I(ft_isprint(INT_MIN), isprint(INT_MIN));
+	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isprint(i), isprint(i)); }
 	return (0);
 }

--- a/srcs/test_ft_isprint.c
+++ b/srcs/test_ft_isprint.c
@@ -11,6 +11,13 @@
 /* ************************************************************************** */
 
 #include "tester.h"
+#ifdef __linux__
+# define LIMIT_MAX 216607
+# define LIMIT_MIN -915936
+#else
+# define LIMIT_MAX INT_MAX
+# define LIMIT_MIN INT_MIN
+#endif
 
 int	main(void)
 {
@@ -39,8 +46,8 @@ int	main(void)
 	/* 23 */ ASSERT_EQ_I(ft_isprint('{'), isprint('}'));
 	/* 24 */ ASSERT_EQ_I(ft_isprint('~'), isprint('~'));
 	/* 25. zero */ ASSERT_EQ_I(ft_isprint(0), isprint(0));
-	/* 26. INT_MAX */ ASSERT_EQ_I(ft_isprint(INT_MAX), isprint(INT_MAX));
-	/* 27. INT_MIN */ ASSERT_EQ_I(ft_isprint(INT_MIN), isprint(INT_MIN));
+	/* 26. INT_MAX */ ASSERT_EQ_I(ft_isprint(LIMIT_MAX), isprint(LIMIT_MAX));
+	/* 27. INT_MIN */ ASSERT_EQ_I(ft_isprint(LIMIT_MIN), isprint(LIMIT_MIN));
 	/* 28 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_isprint(i), isprint(i)); }
 	return (0);
 }

--- a/srcs/test_ft_strncmp.c
+++ b/srcs/test_ft_strncmp.c
@@ -11,6 +11,10 @@
 /* ************************************************************************** */
 
 #include "tester.h"
+#ifdef __linux__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wnonnull"
+#endif
 
 int	main(void)
 {
@@ -45,3 +49,7 @@ int	main(void)
 	/* 59 */ ASSERT_EQ_I(ft_strncmp(NULL, NULL, 0), strncmp(NULL, NULL, 0));
 	return (0);
 }
+
+#ifdef __linux__
+#pragma GCC diagnostic pop
+#endif

--- a/srcs/test_ft_tolower.c
+++ b/srcs/test_ft_tolower.c
@@ -35,6 +35,6 @@ int	main(void)
 	/* 19. zero */ ASSERT_EQ_I(ft_tolower(0), tolower(0));
 	/* 20. INI_MAX */ ASSERT_EQ_I(ft_tolower(INT_MAX), tolower(INT_MAX));
 	/* 21. INT_MIN */ ASSERT_EQ_I(ft_tolower(INT_MIN), tolower(INT_MIN));
-	/* 22 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_tolower(i), tolower(i)); }
+	/* 22 (-1~255) */ for (int i = -1; i < 256; i++) { ASSERT_EQ_I(ft_tolower(i), tolower(i)); }
 	return (0);
 }

--- a/srcs/test_ft_tolower.c
+++ b/srcs/test_ft_tolower.c
@@ -33,8 +33,8 @@ int	main(void)
 	/* 17 */ ASSERT_EQ_I(ft_tolower('{'), tolower('{'));
 	/* 18 */ ASSERT_EQ_I(ft_tolower('~'), tolower('~'));
 	/* 19. zero */ ASSERT_EQ_I(ft_tolower(0), tolower(0));
-	/* 20. INI_MAX */ ASSERT_EQ_I(ft_tolower(INT_MAX), tolower(INT_MAX));
+	/* 20. INT_MAX */ ASSERT_EQ_I(ft_tolower(INT_MAX), tolower(INT_MAX));
 	/* 21. INT_MIN */ ASSERT_EQ_I(ft_tolower(INT_MIN), tolower(INT_MIN));
-	/* 22 (-1~255) */ for (int i = -1; i < 256; i++) { ASSERT_EQ_I(ft_tolower(i), tolower(i)); }
+	/* 22 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_tolower(i), tolower(i)); }
 	return (0);
 }

--- a/srcs/test_ft_toupper.c
+++ b/srcs/test_ft_toupper.c
@@ -35,6 +35,6 @@ int	main(void)
 	/* 19. zero */ ASSERT_EQ_I(ft_toupper(0), toupper(0));
 	/* 20. INI_MAX */ ASSERT_EQ_I(ft_toupper(INT_MAX), toupper(INT_MAX));
 	/* 21. INT_MIN */ ASSERT_EQ_I(ft_toupper(INT_MIN), toupper(INT_MIN));
-	/* 22 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_toupper(i), toupper(i)); }
+	/* 22 (-1~255) */ for (int i = -1; i < 256; i++) { ASSERT_EQ_I(ft_toupper(i), toupper(i)); }
 	return (0);
 }

--- a/srcs/test_ft_toupper.c
+++ b/srcs/test_ft_toupper.c
@@ -33,8 +33,8 @@ int	main(void)
 	/* 17 */ ASSERT_EQ_I(ft_toupper('{'), toupper('{'));
 	/* 18 */ ASSERT_EQ_I(ft_toupper('~'), toupper('~'));
 	/* 19. zero */ ASSERT_EQ_I(ft_toupper(0), toupper(0));
-	/* 20. INI_MAX */ ASSERT_EQ_I(ft_toupper(INT_MAX), toupper(INT_MAX));
+	/* 20. INT_MAX */ ASSERT_EQ_I(ft_toupper(INT_MAX), toupper(INT_MAX));
 	/* 21. INT_MIN */ ASSERT_EQ_I(ft_toupper(INT_MIN), toupper(INT_MIN));
-	/* 22 (-1~255) */ for (int i = -1; i < 256; i++) { ASSERT_EQ_I(ft_toupper(i), toupper(i)); }
+	/* 22 (-256~255) */ for (int i = -256; i < 256; i++) { ASSERT_EQ_I(ft_toupper(i), toupper(i)); }
 	return (0);
 }


### PR DESCRIPTION
## 今回の意図
はじめまして。2024/4に42Tokyoに入学したTakada(42のイントラ名:katakada)と申します。
42Tokyoは2024/6から順次MacOSからUbuntu環境に移行することになりました。
（2024/7/30以降、libftはすべてUbuntu環境で採点が行われるとのことです）
自分は、Ubuntu環境からlibftの課題を始めたのですが、
学生がよく利用しているテスターの多くが、Ubuntu環境では動きませんでした。
そのため、今後の後学のためにlibft-tester-tokyoの42Tokyo Ubuntu環境対応を試みました。

7/30まではubuntu環境でlibftの課題を提出できないため、まだ問題は起こっていませんが、
今後入学してくる学生が、新しい環境でテストツールが使えなくなることは、大変残念なことに思えます。
そのため、ぜひUbuntu対応採択のご検討をお願いいたします。

## 修正方針
- 現状のMacOSでのテスト体験を可能な限り再現すること
- MacOSではこれまで通り使用できるようにすること
## 変更概要
- Ubuntuで実行時ビルドエラーの解消のためのMakefile修正
- Ubuntuで必要なライブラリヘッダーの追加
- malloc_sizeをmalloc_usable_sizeに置き換え
- 関数の挙動の違いを吸収するためのコードをテストコードに追加

## 変更内容
基本的には、利用環境がMacOSかLinuxかを見て、Linuxの場合のみ変更を追加しています
/includes/tester.h
- BSD系ライブラリヘッダーの追加
- マクロインポートのためのヘッダー追加

/libs/libassert/libassert.c
- malloc_sizeをmalloc_usable_sizeに置き換え

/libs/libassert/Makefile
- ccコンパイルオプション -fPICの追加

/Makefile
- ccコンパイルオプション -lbsdの追加
- テスト対象のlibftに対してccコンパイルオプション -fPICの追加

/srcs/test_ft_isalnum.c　test_ft_isalpha.c　test_ft_isdigit.c　test_ft_isprint.c
- Ubuntu環境の場合、0以外の返り値を1に強制
- INT_MAXとINT_MINのテストを未定義に対するテストに変更

srcs/test_ft_strncmp.c
- Ubuntu環境の場合、-Werror=nonnullオプションを解除

srcs/test_ft_tolower.c　test_ft_toupper.c
- 22番のテストについて、ループ範囲を-1~255に変更

/README.md
- Ubuntu環境の場合、ビルド時にCFLAGSが強制的に上書きされる旨の注意追加

## Ubuntu対応のためにやむなくMacOS版テスターを修正した箇所
/srcs/test_ft_isalnum.c　test_ft_isalpha.c　test_ft_isdigit.c　test_ft_isprint.c
- INT_MAXとINT_MINのテストを未定義に対するテストに変更
理由：MacOSとUbuntuで返り値が異なるが、未定義の結果の参照のため、
単純にMacOS環境での返り値を反映させることに意義を見いだせなかったため

srcs/test_ft_tolower.c　test_ft_toupper.c
- 22番のテストについて、ループ範囲を-1~255に変更
理由：マイナス領域の結果について、MacOSとUbuntuで返り値が異なるが、未定義の結果の参照のため、
単純にMacOS環境での返り値を反映させることに意義を見いだせなかったため

## 実施したテスト
レビューと機械採点を通過しているコードを使用して
- 42TokyoのMacOSでの動作を確認 (2024/7/8)
- 42TokyoのUbuntu22.04環境での動作を確認 (2024/7/8)
